### PR TITLE
Simple fix:

### DIFF
--- a/ido-springboard.el
+++ b/ido-springboard.el
@@ -76,6 +76,12 @@
           (t
            nil))))
 
+(defun ido-springboard-add-trap ()
+  (add-hook 'pre-command-hook 'ido-springboard-trap-command t t))
+
+(defun ido-springboard-remove-trap ()
+  (remove-hook 'pre-command-hook 'ido-springboard-trap-command t))
+
 (defun ido-springboard-trap-command ()
   (unless ido-springboard-trapped
     (condition-case err
@@ -92,12 +98,6 @@
               (throw 'abort dir))))
       (error
        (message "Error occurred: %s" err)))))
-
-(defun ido-springboard-add-trap ()
-  (add-hook 'pre-command-hook 'ido-springboard-trap-command t t))
-
-(defun ido-springboard-remove-trap ()
-  (remove-hook 'pre-command-hook 'ido-springboard-trap-command t))
 
 ;;;###autoload
 (defadvice ido-switch-buffer (around ido-springboard-ido-switch-buffer activate)

--- a/springboard.el
+++ b/springboard.el
@@ -102,6 +102,12 @@ disappears, then you need to add that command to this list."
   (defvar springboard-trapped nil)
   (defvar springboard-already-trapped nil))
 
+(defun springboard-add-trap ()
+  (add-hook 'pre-command-hook 'springboard-trap-command t t))
+
+(defun springboard-remove-trap ()
+  (remove-hook 'pre-command-hook 'springboard-trap-command t))
+
 (defun springboard-trap-command ()
   (unless springboard-already-trapped
     (condition-case err
@@ -119,12 +125,6 @@ disappears, then you need to add that command to this list."
           (helm-confirm-and-exit-minibuffer))
       (error
        (message "Error occurred: %s" err)))))
-
-(defun springboard-add-trap ()
-  (add-hook 'pre-command-hook 'springboard-trap-command t t))
-
-(defun springboard-remove-trap ()
-  (remove-hook 'pre-command-hook 'springboard-trap-command t))
 
 (defun springboard-current-history ()
   (let ((recentf-filtered-list


### PR DESCRIPTION
Whenever I was hitting C-b I was getting the following errors in my _Messages_ buffer

read-from-minibuffer: Symbol's function definition is void: ido-springboard-add-trap
Error in minibuffer-exit-hook (ido-springboard-remove-trap): (void-function ido-springboard-remove-trap)

I found a really simple fix for this, declare functions before referencing them. So I thought I should share it
